### PR TITLE
プログラムの修正（リバーシ編）

### DIFF
--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -48,7 +48,7 @@ module ReversiMethods
 
     # コピーした盤面にて石の配置を試みて、成功すれば反映する
     copied_board = Marshal.load(Marshal.dump(board))
-    copied_board[pos.col][pos.row] = stone_color
+    copied_board[pos.row][pos.col] = stone_color
 
     turn_succeed = false
     Position::DIRECTIONS.each do |direction|

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative './position'
+require 'debug'
 
 module ReversiMethods
   WHITE_STONE = 'W'
@@ -62,7 +63,7 @@ module ReversiMethods
 
   def turn(board, target_pos, attack_stone_color, direction)
     return false if target_pos.out_of_board?
-    return false if target_pos.stone_color(board) == attack_stone_color
+    return false if target_pos.stone_color(board) == attack_stone_color || target_pos.stone_color(board) == BLANK_CELL
 
     next_pos = target_pos.next_position(direction)
     if (next_pos.stone_color(board) == attack_stone_color) || turn(board, next_pos, attack_stone_color, direction)

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative './position'
-require 'debug'
 
 module ReversiMethods
   WHITE_STONE = 'W'
@@ -87,6 +86,7 @@ module ReversiMethods
         return true if put_stone(board, position.to_cell_ref, attack_stone_color, dry_run: true)
       end
     end
+    false
   end
 
   def count_stone(board, stone_color)


### PR DESCRIPTION
# 問題が起きている箇所
## エラー① 
テスト内容：最速で勝敗が決まるような盤面（quickest win board）で finished? メソッドがどうなるかを確認するテスト
```
  1) Failure:
ReversiMethodsTest#test_finished_of_quickest_win_board [test/reversi_methods_test.rb:120]:
Expected false to be truthy.
```

エラー内容：trueが変えるべきところが、false が返ってきた。つまり、勝利を決めて終わらなければいけないところが終わらなかった。

### 推論
placeable? → put_stone → turnのどこかでtrueを返している可能性がある。

#### 置きたいマスと隣合うマスがBLANK_CELLの時に、falseが返っているか
調べたい位置 (target_pos)が空欄になっているが、turn関数に再帰してfalseにならずに次の調べたい位置に進んでいる。
```rb
(ruby) target_pos.to_cell_ref # どこを調べてるか（f3, d5 など）
"g1"
(ruby) target_pos.stone_color(board)　# 隣のマスの色
"-"
(ruby) attack_stone_color  
"W" # 今置こうとしているマスの色
```

```rb
#0    ReversiMethods#turn(..., target_pos=..., direction=:right)
#1    ReversiMethods#turn(..., target_pos=..., direction=:right)
```

#### 想定する盤面になっているか
<img width="453" alt="image" src="https://github.com/user-attachments/assets/ffb92d4c-3f28-416f-ad81-349ab5a4f525" />

→なっている。なのに、finished?関数はfalseを返している。

#### placeable?と put_stoneのどちらでtrueを返しているのか
どちらもtrueを返していない。しかし、placeable?関数の返り値がbooleanではなく、ボードの配列を返していた。そのため、finished?関数はそれをtrueとみなしfinished?関数の結果がfalseになっていた。

<img width="303" alt="image" src="https://github.com/user-attachments/assets/e71cae91-8648-411a-9a9e-07ea9defaeb2" />

### 解決策
- 「1つ隣の駒が空欄の時はfalse」という条件を入れる
- placeable?関数で、falseを返すようにする

## 2つ目のエラー
Bが置かれている位置が違っている。put_stone関数が間違っている可能性がある
```
Failure:
ReversiMethodsTest#test_put_stone [test/reversi_methods_test.rb:38]:
--- expected
+++ actual
@@ -1 +1 @@
-[["-", "-", "-", "-", "-", "-", "-", "-"], ["-", "-", "-", "-", "-", "-", "-", "-"], ["-", "-", "-", "-", "-", "-", "-", "-"], ["-", "-", "-", "W", "B", "-", "-", "-"], ["-", "-", "-", "B", "B", "-", "-", "-"], ["-", "-", "-", "-", "B", "-", "-", "-"], ["-", "-", "-", "-", "-", "-", "-", "-"], ["-", "-", "-", "-", "-", "-", "-", "-"]]
+[["-", "-", "-", "-", "-", "-", "-", "-"], ["-", "-", "-", "-", "-", "-", "-", "-"], ["-", "-", "-", "-", "-", "-", "-", "-"], ["-", "-", "-", "W", "B", "-", "-", "-"], ["-", "-", "-", "B", "B", "B", "-", "-"], ["-", "-", "-", "-", "-", "-", "-", "-"], ["-", "-", "-", "-", "-", "-", "-", "-"], ["-", "-", "-", "-", "-", "-", "-", "-"]]
```

### 原因
既存のボードをコピーする際に、rowとcolが逆の位置で設定していた。
e6 (5, 4)に置きたいけど、f7 (6, 5)に置かれている。
f4 (3, 5)に置きたいけど、g5 (4, 6)に置かれている。

e6の時。
**コピー前のボード**
<img width="299" alt="image" src="https://github.com/user-attachments/assets/a40d8ebc-d9b8-4bdd-b326-c520d40103e0" />

**コピーした後のボード**
<img width="299" alt="image" src="https://github.com/user-attachments/assets/1a053725-8c58-431e-9e3d-b34b0d7eb9a4" />

### 解決策
盤面をコピーする際のrowとcolの位置を入れ替える




